### PR TITLE
Fix ADPCMA channel volume and adjust balance

### DIFF
--- a/jt12/hdl/adpcm/jt10_adpcm.v
+++ b/jt12/hdl/adpcm/jt10_adpcm.v
@@ -44,7 +44,7 @@ reg [5:0] step_next, step_1p;
 reg       sign2, sign3, sign4, sign5, xsign5;
 
 // All outputs from stage 1
-wire [sigw-1:0] inc3_long = { {sigw-11{1'b0}},inc3[11:1] };
+assign pcm = { {16-sigw{x1[sigw-1]}}, x1 } <<< shift;
 
 // This could be decomposed in more steps as the pipeline
 // has room for it
@@ -76,7 +76,7 @@ jt10_adpcma_lut u_lut(
 // 666 kHz -> 18.5 kHz = 55.5/3 kHz
 
 reg chon2, chon3, chon4;
-wire [sigw-1:0] inc3_long = { {sigw-12{1'b0}},inc3 };
+wire [sigw-1:0] inc3_long = { {sigw-11{1'b0}},inc3[11:1] };
 
 always @( posedge clk or negedge rst_n )
     if( ! rst_n ) begin

--- a/jt12/hdl/adpcm/jt10_adpcm.v
+++ b/jt12/hdl/adpcm/jt10_adpcm.v
@@ -44,7 +44,7 @@ reg [5:0] step_next, step_1p;
 reg       sign2, sign3, sign4, sign5, xsign5;
 
 // All outputs from stage 1
-assign pcm = { {16-sigw{x1[sigw-1]}}, x1 } <<< shift;
+wire [sigw-1:0] inc3_long = { {sigw-11{1'b0}},inc3[11:1] };
 
 // This could be decomposed in more steps as the pipeline
 // has room for it

--- a/jt12/hdl/adpcm/jt10_adpcm_gain.v
+++ b/jt12/hdl/adpcm/jt10_adpcm_gain.v
@@ -91,7 +91,7 @@ always @(posedge clk or negedge rst_n)
         lracl4  <= lracl3;
         // IV: new data is accepted here
         lracl5  <= lracl4;
-        db5     <= { 1'b0, ~lracl4[5:0] } + {1'b0, ~atl};
+        db5     <= { 2'b0, ~lracl4[4:0] } + {1'b0, ~atl};
         // V
         lracl6  <= lracl5;
         lin6    <= lin_5b;

--- a/jt12/hdl/jt10_acc.v
+++ b/jt12/hdl/jt10_acc.v
@@ -79,8 +79,8 @@ reg acc_en_l, acc_en_r;
 always @(*)
     case( {cur_op,cur_ch} )
         {2'd0,3'd2}: begin // ADPCM-A:
-            acc_input_l = (adpcmA_l[15] & ~&adpcmA_l[14:11]) ? 16'hC000 : (~adpcmA_l[15] & |adpcmA_l[14:11]) ? 16'h3FFF : {adpcmA_l[11],adpcmA_l[11:0],3'd0};
-            acc_input_r = (adpcmA_r[15] & ~&adpcmA_r[14:11]) ? 16'hC000 : (~adpcmA_r[15] & |adpcmA_r[14:11]) ? 16'h3FFF : {adpcmA_r[11],adpcmA_r[11:0],3'd0};
+            acc_input_l = adpcmA_l;
+            acc_input_r = adpcmA_r;
             `ifndef NOMIX
             acc_en_l    = 1'b1;
             acc_en_r    = 1'b1;
@@ -90,8 +90,8 @@ always @(*)
             `endif
         end
         {2'd0,3'd6}: begin // ADPCM-B:
-            acc_input_l = adpcmB_l>>>3; // Operator width is 14 bit, ADPCM-B is 16 bit
-            acc_input_r = adpcmB_r>>>3; // accumulator width per input channel is 14 bit
+            acc_input_l = adpcmB_l>>>1; // Operator width is 14 bit, ADPCM-B is 16 bit
+            acc_input_r = adpcmB_r>>>1; // accumulator width per input channel is 14 bit
             `ifndef NOMIX
             acc_en_l    = 1'b1;
             acc_en_r    = 1'b1;


### PR DESCRIPTION
- The ADPCMA channel volume is only 5 bits wide.
- Changing this requires rebalancing audio levels.