### PR TITLE
Fix missing ADPCMA samples

### DIFF
--- a/jt12/hdl/adpcm/jt10_adpcm_cnt.v
+++ b/jt12/hdl/adpcm/jt10_adpcm_cnt.v
@@ -153,7 +153,7 @@ always @(posedge clk or negedge rst_n)
         addr5  <= addr4;
         on5    <= on4;
         clr5   <= clr4;
-        done5  <= addr4[20:9] == end4 && addr4[8:0]==~9'b0;
+        done5  <= addr4[20:9] == end4 && addr4[8:0]==~9'b0 && ~(clr4 && on4);
         start5 <= start4;
         end5   <= end4;
         bank5  <= bank4;


### PR DESCRIPTION
When a new aon event is received, if the last sample played ends with same address as the new one, a done is immediately triggered.  This means if the same sample is played repeatedly, every other one will be dropped.  The same can happen for other samples with same end address, even if they are in different banks.  This fixes the issue.