### PR TITLE
Add Autosave (OSD)

### DIFF
--- a/NeoGeo.qsf
+++ b/NeoGeo.qsf
@@ -13,7 +13,7 @@ set_global_assignment -name PARTITION_NETLIST_TYPE SOURCE -section_id Top
 set_global_assignment -name PARTITION_FITTER_PRESERVATION_LEVEL PLACEMENT_AND_ROUTING -section_id Top
 set_global_assignment -name PARTITION_COLOR 16764057 -section_id Top
 
-set_global_assignment -name LAST_QUARTUS_VERSION "17.0.2 Standard Edition"
+set_global_assignment -name LAST_QUARTUS_VERSION "17.1.0 Lite Edition"
 
 set_global_assignment -name GENERATE_RBF_FILE ON
 set_global_assignment -name PROJECT_OUTPUT_DIRECTORY output_files

--- a/mem/backup.v
+++ b/mem/backup.v
@@ -27,9 +27,14 @@ module backup(
 	input clk_sys,
 	input [14:0] sram_addr,
 	input sram_wr,
+	output reg sram_change,
 	input [15:0] sd_buff_dout,
 	output [15:0] sd_buff_din_sram
 );
+
+always @(posedge CLK_24M) begin
+	sram_change = (~nBWL | ~nBWU);
+end
 
 	dpram #(.ADDRWIDTH(15)) SRAML(
 		.clock_a(CLK_24M),
@@ -51,7 +56,7 @@ module backup(
 		.wren_a(~nBWU),
 		.data_a(M68K_DATA[15:8]),
 		.q_a(SRAM_OUT[15:8]),
-		
+
 		.clock_b(clk_sys),
 		.address_b(sram_addr),
 		.wren_b(sram_wr),

--- a/mem/memcard.v
+++ b/mem/memcard.v
@@ -28,9 +28,18 @@ module memcard(
 	input clk_sys,
 	input [11:0] memcard_addr,
 	input memcard_wr,
+	output reg memcard_change,
 	input [15:0] sd_buff_dout,
 	output [15:0] sd_buff_din_memcard
 );
+
+wire wren_aL = CARD_WE & CDA[0];
+wire wren_aU = CARD_WE & ~CDA[0];
+
+always @(posedge CLK_24M) begin.
+	// Can probably be simplified as "memcard_change = CARD_WE"
+	memcard_change = wren_aL | wren_aU;
+end
 
 	wire [7:0] CDD_L;
 	wire [7:0] CDD_U;
@@ -45,7 +54,7 @@ module memcard(
 	dpram #(.ADDRWIDTH(12)) MEMCARDL(
 		.clock_a(CLK_24M),
 		.address_a(CDA_MASKED),
-		.wren_a(CARD_WE & CDA[0]),
+		.wren_a(wren_aL),
 		.data_a(M68K_DATA),
 		.q_a(CDD_L),
 		
@@ -59,7 +68,7 @@ module memcard(
 	dpram #(.ADDRWIDTH(12)) MEMCARDU(
 		.clock_a(CLK_24M),
 		.address_a(CDA_MASKED),
-		.wren_a(CARD_WE & ~CDA[0]),
+		.wren_a(wren_aU),
 		.data_a(M68K_DATA),
 		.q_a(CDD_U),
 		


### PR DESCRIPTION
For backup & memory card (Compatible with MVS & AES).
It only triggers when OSD menu opens and there has been a change (standard practice). It does not perform any writes otherwise.