### PR TITLE
Reduce ROM duplication for gog.com game variants.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In addition, several bios files must be placed in the **NEOGEO** folder for the 
 
 Sometimes these files may be named slightly differently depending on where they are obtained, but they must be renamed to match the filenames above to work with MiSTer. You may choose between using original system BIOS (sp-s2.sp1/neo-epo.sp1) and uni-bios.rom. Using uni-bios is recommended, and can be obtained [here](http://unibios.free.fr/).
 
-Lastly, **romsets.xml** from the release folder must also be placed in the directory. The provided XML is for Darksoft ROMs only, you must make your own for MAME ROMs. This file describes to the core where the ROM sets are located and how to load them.
+Lastly, **romsets.xml** from the release folder must also be placed in the directory. The provided XML is for Darksoft ROMs only, you must make your own for MAME ROMs. This file describes to the core where the ROM sets are located and how to load them. **gog-romsets.xml** can be used (renamed to **romsets.xml**) for games purchased from gog.com (which also include all the needed bios files), see comments in gog-romsets.xml .
 
 ## Saving and Loading
 In AES mode, all saves are to the memory card only. In MVS mode, some games and uni-bios save their settings to a special area of battery backed ram built into the system, while game data can be still be saved to a memory card. To simplify things, it is suggested to stick to one system type on the OSD and use uni-bios to change the system type, so that game information is saved consistently.

--- a/releases/gog-romsets.xml
+++ b/releases/gog-romsets.xml
@@ -23,6 +23,27 @@ NeoGeo
       (etc, all files from the zip)
     (etc)
 
+Notes on variants
+Some games contain multiple variants (ex: samsho2 also contains samsho2k,
+which in turn is all that is needed for samsho2k2). For these, create an
+empty folder with the variant name (no need to duplicate its content):
+NeoGeo
+  gog
+    samsho2
+      063-p1.p1
+      (etc)
+    samsho2k
+    samsho2k2
+For mslug2t (GOG roms patched with turbo mod), only the produced 941-p1.p1
+file is needed in mslug2t folder:
+NeoGeo
+  gog
+    mslug2
+      241-p1.p1
+      (etc)
+    mslug2t
+      941-p1.p1
+
 -->
 
 <romsets>
@@ -44,20 +65,20 @@ NeoGeo
 		<file name="058-v3.v3" index="24"/>
 	</romset>
 	<romset name="fatfurspa" pcm="1" altname="Fatal Fury Special (set 2)" publisher="SNK" year="1993">
-		<file name="058-p1.p1" index="4"/>
-		<file name="058-p2.sp2" index="6"/>
-		<file name="058-epr.ep1" index="4"/>
-		<file name="058-s1.s1" index="8"/>
-		<file name="058-c1.c1" index="64"/>
-		<file name="058-c2.c2" index="65"/>
-		<file name="058-c3.c3" index="72"/>
-		<file name="058-c4.c4" index="73"/>
-		<file name="058-c5.c5" index="80"/>
-		<file name="058-c6.c6" index="81"/>
-		<file name="058-m1.m1" index="9"/>
-		<file name="058-v1.v1" index="16"/>
-		<file name="058-v2.v2" index="20"/>
-		<file name="058-v3.v3" index="24"/>
+		<file name="../fatfursp/058-p1.p1" index="4"/>
+		<file name="../fatfursp/058-p2.sp2" index="6"/>
+		<file name="../fatfursp/058-epr.ep1" index="4"/>
+		<file name="../fatfursp/058-s1.s1" index="8"/>
+		<file name="../fatfursp/058-c1.c1" index="64"/>
+		<file name="../fatfursp/058-c2.c2" index="65"/>
+		<file name="../fatfursp/058-c3.c3" index="72"/>
+		<file name="../fatfursp/058-c4.c4" index="73"/>
+		<file name="../fatfursp/058-c5.c5" index="80"/>
+		<file name="../fatfursp/058-c6.c6" index="81"/>
+		<file name="../fatfursp/058-m1.m1" index="9"/>
+		<file name="../fatfursp/058-v1.v1" index="16"/>
+		<file name="../fatfursp/058-v2.v2" index="20"/>
+		<file name="../fatfursp/058-v3.v3" index="24"/>
 	</romset>
 	<romset name="ironclad" pcm="1" altname="Iron Clad" altnamej="Choutetsu Brikinger" publisher="Saurus" year="1996">
 		<file name="proto_220-p1.p1" index="4" offset="0x100000" length="0x100000"/>
@@ -72,16 +93,16 @@ NeoGeo
 	</romset>
 	<!-- Program ROM bank 0 does not pass CRC check as of Unibios 3.3 -->
 	<romset name="ironclado" pcm="1" altname="Iron Clad (bootleg)" altnamej="Choutetsu Brikinger" publisher="Saurus" year="1996">
-		<file name="proto_220-p1.p1" index="4" offset="0x100000" length="0x100000"/>
-		<file name="proto_220-p1.p1" index="6" offset="0x000000" length="0x100000"/>
-		<file name="220-p1a.bin" index="6"/>
-		<file name="proto_220-s1.s1" index="8"/>
-		<file name="proto_220-c1.c1" index="64"/>
-		<file name="proto_220-c2.c2" index="65"/>
-		<file name="proto_220-c3.c3" index="80"/>
-		<file name="proto_220-c4.c4" index="81"/>
-		<file name="proto_220-m1.m1" index="9"/>
-		<file name="proto_220-v1.v1" index="16"/>
+		<file name="../ironclad/proto_220-p1.p1" index="4" offset="0x100000" length="0x100000"/>
+		<file name="../ironclad/proto_220-p1.p1" index="6" offset="0x000000" length="0x100000"/>
+		<file name="../ironclad/220-p1a.bin" index="6"/>
+		<file name="../ironclad/proto_220-s1.s1" index="8"/>
+		<file name="../ironclad/proto_220-c1.c1" index="64"/>
+		<file name="../ironclad/proto_220-c2.c2" index="65"/>
+		<file name="../ironclad/proto_220-c3.c3" index="80"/>
+		<file name="../ironclad/proto_220-c4.c4" index="81"/>
+		<file name="../ironclad/proto_220-m1.m1" index="9"/>
+		<file name="../ironclad/proto_220-v1.v1" index="16"/>
 	</romset>
 	<romset name="kotm" pcm="1" altname="King of the Monsters" publisher="SNK" year="1991">
 		<file name="016-p1.p1" index="4"/>
@@ -96,16 +117,16 @@ NeoGeo
 		<file name="016-v2.v2" index="18"/>
 	</romset>
 	<romset name="kotmh" pcm="1" altname="King of the Monsters (set 2)" publisher="SNK" year="1991">
-		<file name="016-hp1.p1" index="4"/>
-		<file name="016-p2.p2" index="5"/>
-		<file name="016-s1.s1" index="8"/>
-		<file name="016-c1.c1" index="64"/>
-		<file name="016-c2.c2" index="65"/>
-		<file name="016-c3.c3" index="68"/>
-		<file name="016-c4.c4" index="69"/>
-		<file name="016-m1.m1" index="9"/>
-		<file name="016-v1.v1" index="16"/>
-		<file name="016-v2.v2" index="18"/>
+		<file name="../kotm/016-hp1.p1" index="4"/>
+		<file name="../kotm/016-p2.p2" index="5"/>
+		<file name="../kotm/016-s1.s1" index="8"/>
+		<file name="../kotm/016-c1.c1" index="64"/>
+		<file name="../kotm/016-c2.c2" index="65"/>
+		<file name="../kotm/016-c3.c3" index="68"/>
+		<file name="../kotm/016-c4.c4" index="69"/>
+		<file name="../kotm/016-m1.m1" index="9"/>
+		<file name="../kotm/016-v1.v1" index="16"/>
+		<file name="../kotm/016-v2.v2" index="18"/>
 	</romset>
 	<romset name="mslug" pcm="1" altname="Metal Slug - Super Vehicle-001" publisher="Nazca" year="1996">
 		<file name="201-p1.p1" index="4" offset="0x100000" length="0x100000"/>
@@ -134,15 +155,15 @@ NeoGeo
 	<!-- 941-p1.p1 can be generated using the patch available from http://blog.system11.org/?p=1442 -->
 	<romset name="mslug2t" pcm="1" altname="Metal Slug 2 Turbo - Super Vehicle-001-II" publisher="SNK" year="1998">
 		<file name="941-p1.p1" index="4"/>
-		<file name="241-p2.sp2" index="6"/>
-		<file name="241-s1.s1" index="8"/>
-		<file name="241-c1.c1" index="64"/>
-		<file name="241-c2.c2" index="65"/>
-		<file name="241-c3.c3" index="96"/>
-		<file name="241-c4.c4" index="97"/>
-		<file name="241-m1.m1" index="9"/>
-		<file name="241-v1.v1" index="16"/>
-		<file name="241-v2.v2" index="24"/>
+		<file name="../mslug2/241-p2.sp2" index="6"/>
+		<file name="../mslug2/241-s1.s1" index="8"/>
+		<file name="../mslug2/241-c1.c1" index="64"/>
+		<file name="../mslug2/241-c2.c2" index="65"/>
+		<file name="../mslug2/241-c3.c3" index="96"/>
+		<file name="../mslug2/241-c4.c4" index="97"/>
+		<file name="../mslug2/241-m1.m1" index="9"/>
+		<file name="../mslug2/241-v1.v1" index="16"/>
+		<file name="../mslug2/241-v2.v2" index="24"/>
 	</romset>
 	<romset name="samsho2" pcm="1" altname="Samurai Shodown II" publisher="SNK" year="1994">
 		<file name="063-p1.p1" index="4" offset="0x100000" length="0x100000"/>
@@ -163,42 +184,42 @@ NeoGeo
 		<file name="063-v4.v4" index="28"/>
 	</romset>
 	<romset name="samsho2k" pcm="1" altname="Samurai Shodown II Korean" publisher="SNK" year="1994">
-		<file name="063-p1-kan.p1" index="4" offset="0x100000" length="0x100000"/>
-		<file name="063-p1-kan.p1" index="6" offset="0x000000" length="0x100000"/>
-		<file name="063-ep1-kan.ep1" index="4"/>
-		<file name="063-ep2-kan.ep2" index="5"/>
-		<file name="063-s1-kan.s1" index="8"/>
-		<file name="063-c1.c1" index="64"/>
-		<file name="063-c2.c2" index="65"/>
-		<file name="063-c3.c3" index="72"/>
-		<file name="063-c4.c4" index="73"/>
-		<file name="063-c5.c5" index="80"/>
-		<file name="063-c6.c6" index="81"/>
-		<file name="063-c7.c7" index="88"/>
-		<file name="063-c8.c8" index="89"/>
-		<file name="063-m1.m1" index="9"/>
-		<file name="063-v1.v1" index="16"/>
-		<file name="063-v2.v2" index="20"/>
-		<file name="063-v3.v3" index="24"/>
-		<file name="063-v4.v4" index="28"/>
+		<file name="../samsho2/063-p1-kan.p1" index="4" offset="0x100000" length="0x100000"/>
+		<file name="../samsho2/063-p1-kan.p1" index="6" offset="0x000000" length="0x100000"/>
+		<file name="../samsho2/063-ep1-kan.ep1" index="4"/>
+		<file name="../samsho2/063-ep2-kan.ep2" index="5"/>
+		<file name="../samsho2/063-s1-kan.s1" index="8"/>
+		<file name="../samsho2/063-c1.c1" index="64"/>
+		<file name="../samsho2/063-c2.c2" index="65"/>
+		<file name="../samsho2/063-c3.c3" index="72"/>
+		<file name="../samsho2/063-c4.c4" index="73"/>
+		<file name="../samsho2/063-c5.c5" index="80"/>
+		<file name="../samsho2/063-c6.c6" index="81"/>
+		<file name="../samsho2/063-c7.c7" index="88"/>
+		<file name="../samsho2/063-c8.c8" index="89"/>
+		<file name="../samsho2/063-m1.m1" index="9"/>
+		<file name="../samsho2/063-v1.v1" index="16"/>
+		<file name="../samsho2/063-v2.v2" index="20"/>
+		<file name="../samsho2/063-v3.v3" index="24"/>
+		<file name="../samsho2/063-v4.v4" index="28"/>
 	</romset>
 	<romset name="samsho2k2" pcm="1" altname="Samurai Shodown II Korean 2" publisher="SNK" year="1994">
-		<file name="063-p1-kan.p1" index="4" offset="0x100000" length="0x100000"/>
-		<file name="063-p1-kan.p1" index="6" offset="0x000000" length="0x100000"/>
-		<file name="063-s1-kan.s1" index="8"/>
-		<file name="063-c1.c1" index="64"/>
-		<file name="063-c2.c2" index="65"/>
-		<file name="063-c3.c3" index="72"/>
-		<file name="063-c4.c4" index="73"/>
-		<file name="063-c5.c5" index="80"/>
-		<file name="063-c6.c6" index="81"/>
-		<file name="063-c7.c7" index="88"/>
-		<file name="063-c8.c8" index="89"/>
-		<file name="063-m1.m1" index="9"/>
-		<file name="063-v1.v1" index="16"/>
-		<file name="063-v2.v2" index="20"/>
-		<file name="063-v3.v3" index="24"/>
-		<file name="063-v4.v4" index="28"/>
+		<file name="../samsho2/063-p1-kan.p1" index="4" offset="0x100000" length="0x100000"/>
+		<file name="../samsho2/063-p1-kan.p1" index="6" offset="0x000000" length="0x100000"/>
+		<file name="../samsho2/063-s1-kan.s1" index="8"/>
+		<file name="../samsho2/063-c1.c1" index="64"/>
+		<file name="../samsho2/063-c2.c2" index="65"/>
+		<file name="../samsho2/063-c3.c3" index="72"/>
+		<file name="../samsho2/063-c4.c4" index="73"/>
+		<file name="../samsho2/063-c5.c5" index="80"/>
+		<file name="../samsho2/063-c6.c6" index="81"/>
+		<file name="../samsho2/063-c7.c7" index="88"/>
+		<file name="../samsho2/063-c8.c8" index="89"/>
+		<file name="../samsho2/063-m1.m1" index="9"/>
+		<file name="../samsho2/063-v1.v1" index="16"/>
+		<file name="../samsho2/063-v2.v2" index="20"/>
+		<file name="../samsho2/063-v3.v3" index="24"/>
+		<file name="../samsho2/063-v4.v4" index="28"/>
 	</romset>
 	<romset name="twinspri" pcm="1" altname="Twinkle Star Sprites" publisher="ADK / SNK" year="1996">
 		<file name="224-p1.p1" index="4" offset="0x100000" length="0x100000"/>


### PR DESCRIPTION
Also, advertise its existence in README.

I picked the "variants folders are empty" approach because it makes game folder creation easier: just extract game zip file in its directory. No need to move bits to other folders. The exception is mslug2t, as the extra file does not come from gog.com's zip file. The resulting layout may be a bit confusing, with empty folders which still "do" something, or the need to keep the original folder around.

More ideas welcome, and I can update this patch.