### PR TITLE
Fixes PSG pitch

### DIFF
--- a/rtl/jt12/hdl/jt10.v
+++ b/rtl/jt12/hdl/jt10.v
@@ -40,7 +40,7 @@ module jt10(
     input   [7:0]   adpcma_data,  // Data from RAM
     output  [23:0]  adpcmb_addr,  // real hardware has 12 pins multiplexed through PMPX pin
     output          adpcmb_roe_n, // ADPCM-B ROM output enable
-	 input	[7:0]	  adpcmb_data,
+    input   [7:0]     adpcmb_data,
     // Separated output
     output          [ 7:0] psg_A,
     output          [ 7:0] psg_B,
@@ -57,7 +57,8 @@ module jt10(
 
 // Uses 6 FM channels but only 4 are outputted
 jt12_top #(
-    .use_lfo(1),.use_ssg(1), .num_ch(6), .use_pcm(0), .use_adpcm(1), .use_clkdiv(0) )
+    .use_lfo(1),.use_ssg(1), .num_ch(6), .use_pcm(0), .use_adpcm(1), .use_clkdiv(0),
+    .JT49_DIV(3) )
 u_jt12(
     .rst            ( rst          ),        // rst should be at least 6 clk&cen cycles long
     .clk            ( clk          ),        // CPU clock
@@ -74,7 +75,7 @@ u_jt12(
     .adpcma_bank    ( adpcma_bank  ),
     .adpcma_roe_n   ( adpcma_roe_n ), // ADPCM-A ROM output enable
     .adpcma_data    ( adpcma_data  ), // Data from RAM
-	 
+     
     .adpcmb_addr    ( adpcmb_addr  ), // real hardware has 12 pins multiplexed through PMPX pin
     .adpcmb_roe_n   ( adpcmb_roe_n ), // ADPCM-B ROM output enable
     .adpcmb_data    ( adpcmb_data  ), // Data from RAM

--- a/rtl/jt12/hdl/jt12_top.v
+++ b/rtl/jt12/hdl/jt12_top.v
@@ -68,6 +68,7 @@ module jt12_top (
 // defaults to YM2612
 parameter use_lfo=1, use_ssg=0, num_ch=6, use_pcm=1;
 parameter use_adpcm=0, use_clkdiv=1;
+parameter JT49_DIV=2;
 
 wire flag_A, flag_B, busy;
 
@@ -448,7 +449,7 @@ endgenerate
 `ifndef NOSSG
 generate
     if( use_ssg==1 ) begin : gen_ssg
-        jt49 #(.COMP(2'b01), .CLKDIV(2)) 
+        jt49 #(.COMP(2'b01), .CLKDIV(JT49_DIV)) 
             u_psg( // note that input ports are not multiplexed
             .rst_n      ( ~rst      ),
             .clk        ( clk       ),    // signal on positive edge


### PR DESCRIPTION
PSG needs an extra divider in YM2610 compared with YM2608. This introduces that. The pitch is noticeable in the "insert coin" sound of Art of Fighting, for instance.