### PR TITLE
fix incorrect expansion of colors

### DIFF
--- a/neogeo.sv
+++ b/neogeo.sv
@@ -1749,9 +1749,9 @@ wire [6:0] R6 = {1'b0, PAL_RAM_REG[11:8], PAL_RAM_REG[14], PAL_RAM_REG[11]} - PA
 wire [6:0] G6 = {1'b0, PAL_RAM_REG[7:4],  PAL_RAM_REG[13], PAL_RAM_REG[7] } - PAL_RAM_REG[15];
 wire [6:0] B6 = {1'b0, PAL_RAM_REG[3:0],  PAL_RAM_REG[12], PAL_RAM_REG[3] } - PAL_RAM_REG[15];
 
-wire [7:0] R8 = R6[6] ? 8'd0 : {R6[5:0],  R6[5:4]};
-wire [7:0] G8 = G6[6] ? 8'd0 : {G6[5:0],  G6[5:4]};
-wire [7:0] B8 = B6[6] ? 8'd0 : {B6[5:0],  B6[5:4]};
+wire [7:0] R8 = R6[6] ? 8'd0 : {R6[5:0],  R6[4:3]};
+wire [7:0] G8 = G6[6] ? 8'd0 : {G6[5:0],  G6[4:3]};
+wire [7:0] B8 = B6[6] ? 8'd0 : {B6[5:0],  B6[4:3]};
 
 wire [7:0] r,g,b;
 wire hs,vs,hblank,vblank;


### PR DESCRIPTION
The MSB was accidently being used twice in color expansion causing an uneven color ramp.