### PR TITLE
Add Xeno Crisis ROM

### DIFF
--- a/releases/romsets.xml
+++ b/releases/romsets.xml
@@ -211,6 +211,9 @@ https://lmgtfy.com/?q=darksoft+neo+geo+roll-up+pack
 	<romset name="shocktr2" pcm="1" altname="Shock Troopers: 2nd Squad" publisher="Saurus" year="1998" ram="1"/>
 	<romset name="shocktro,shcktroa" pcm="1" altname="Shock Troopers" publisher="Saurus" year="1997" ram="1"/>
 
+	<!-- Not in darksoft pack -->
+	<romset name="xenocrisis" vromb_offset="0x1000000" altname="Xeno Crisis" altnamej="Xeno Crisis" publisher="Bitmap Bureau Ltd" year="2021"/>
+
 	<!-- ROMs requiring 96MB SDRAM (32MB+64MB) -->
 
 	<romset name="garou" cmc="1" sma="2" pcm="1" altname="Garou: Mark of the Wolves" publisher="SNK" year="1999" ram="2"/>


### PR DESCRIPTION
Per the [ROM](https://shop.bitmapbureau.com/products/xeno-crisis-neo-geo-aes-mvs-rom-download)'s `README`:

```
Please note that currently the MisterFPGA romset is the only one capable of replicating the full stereo output for music, using the original 32MB VROM that comes with the hardware release of Xeno Crisis.

...

MisterFPGA

Create a folder called xenocrisis with the supplied MisterFPGA ROM files alongside other neogeo games and then copy the text in the provided romset.xml into the romset.xml file for the NeoGeo core.
```