### PR TITLE
Add Status Bit Map

### DIFF
--- a/neogeo.sv
+++ b/neogeo.sv
@@ -241,7 +241,6 @@ video_freak video_freak
 // G:	status[11:10]	Neo CD region
 // C:	status[12]		Save memory card & backup RAM
 // L:	status[12]		CD lid state (DEBUG)
-//  :	status[13]		Primary SDRAM size 32MB/64MB
 //  :	status[14]		Manual Reset
 //  :	status[20:15]  OSD options
 // 0123456789 ABCDEFGHIJKLMNO
@@ -250,10 +249,17 @@ video_freak video_freak
 // Con Arc CD CDz
 // 00  01  10 11
 // F   F   +  +  ~SYSTEM_CDx;
-// +   +   S  S  SYSTEM_CDx; 
+// +   +   S  S  SYSTEM_CDx;
 // O   O   +  +  ~SYSTEM_CDx;
-// +   O   +  +  SYSTEM_MVS; 
-// +   +   O  O  SYSTEM_CDx;   
+// +   O   +  +  SYSTEM_MVS;
+// +   +   O  O  SYSTEM_CDx;
+
+// Status Bit Map:
+//             Upper                             Lower              
+// 0         1         2         3          4         5         6   
+// 01234567890123456789012345678901 23456789012345678901234567890123
+// 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
+// XXXXXXXXXXXXX XXX XXXXX XXXXX    XXXXXXXXXXX              XXXXXX 
 
 `include "build_id.v"
 localparam CONF_STR = {


### PR DESCRIPTION
Add Status Bit Map as documentation in core was not updated, removed the primary sdram size status bit documentation as it doesn't seem to be populated in the OSD or used in the core anywhere.