### PR TITLE
Fix missing Blue's Journey instruments

### DIFF
--- a/releases/romsets.xml
+++ b/releases/romsets.xml
@@ -35,7 +35,7 @@ https://lmgtfy.com/?q=darksoft+neo+geo+roll-up+pack
 	<romset name="b2b" pcm="1" altname="Bang Bang Busters" publisher="Visco" year="2000"/>
 	<romset name="bakatono" pcm="1" altname="Bakatonosama Mahjong Manyuuki" publisher="Monolith Corp." year="1991"/>
 	<romset name="bangbead" pcm="1" altname="Bang Bead" publisher="Visco" year="2000"/>
-	<romset name="bjourney" pcm="0" altname="Blue's Journey" altnamej="Raguy" publisher="Alpha Denshi Co." year="1990" vromb_offset="0x200000" vrom_mirror="0"/>
+	<romset name="bjourney" pcm="0" altname="Blue's Journey" altnamej="Raguy" publisher="Alpha Denshi Co." year="1990" vromb_offset="0x200000"/>
 	<romset name="breakers" pcm="1" altname="Breakers" publisher="Visco" year="1996"/>
 	<romset name="breakrev" pcm="1" altname="Breakers Revenge" publisher="Visco" year="1998"/>
 	<romset name="bstars" pcm="0" altname="Baseball Stars Professional" publisher="SNK" year="1990" vromb_offset="0x200000"/>


### PR DESCRIPTION
Blue's Journey vroma0 file is 3MB.  It appears the first MB is for ADPCMA, the middle 2MB appears to be blank (and is currently being written to ADPCMA memory space after the first MB; this doesn't appear to cause issues). The third MB looks like it is for ADPCMB.  The code appears to reference  samples at 0x1XXXXX. This requires mirroring to work.