### PR TITLE
Change clr_flag to not mute adpcm channels.

### DIFF
--- a/releases/romsets.xml
+++ b/releases/romsets.xml
@@ -35,7 +35,7 @@ https://lmgtfy.com/?q=darksoft+neo+geo+roll-up+pack
 	<romset name="b2b" pcm="1" altname="Bang Bang Busters" publisher="Visco" year="2000"/>
 	<romset name="bakatono" pcm="1" altname="Bakatonosama Mahjong Manyuuki" publisher="Monolith Corp." year="1991"/>
 	<romset name="bangbead" pcm="1" altname="Bang Bead" publisher="Visco" year="2000"/>
-	<romset name="bjourney" pcm="0" altname="Blue's Journey" altnamej="Raguy" publisher="Alpha Denshi Co." year="1990" vromb_offset="0x200000" vrom_mirror="0"/>
+	<romset name="bjourney" pcm="0" altname="Blue's Journey" altnamej="Raguy" publisher="Alpha Denshi Co." year="1990" vromb_offset="0x200000"/>
 	<romset name="breakers" pcm="1" altname="Breakers" publisher="Visco" year="1996"/>
 	<romset name="breakrev" pcm="1" altname="Breakers Revenge" publisher="Visco" year="1998"/>
 	<romset name="bstars" pcm="0" altname="Baseball Stars Professional" publisher="SNK" year="1990" vromb_offset="0x200000"/>

--- a/rtl/jt12/hdl/adpcm/jt10_adpcm_drvB.v
+++ b/rtl/jt12/hdl/adpcm/jt10_adpcm_drvB.v
@@ -47,7 +47,7 @@ module jt10_adpcm_drvB(
 
 wire nibble_sel;
 wire adv;           // advance to next reading
-wire restart;
+wire clr_dec;
 wire chon;
 
 // `ifdef SIMULATION
@@ -79,7 +79,7 @@ jt10_adpcmb_cnt u_cnt(
     .chon        ( chon            ),
     .clr_flag    ( clr_flag        ),
     .flag        ( flag            ),
-    .restart     ( restart         ),
+    .clr_dec     ( clr_dec         ),
     .adv         ( adv             )
 );
 
@@ -96,7 +96,7 @@ jt10_adpcmb u_decoder(
     .adv    ( adv & cen55    ),
     .data   ( din            ),
     .chon   ( chon           ),
-    .clr    ( flag | restart ),
+    .clr    ( clr_dec        ),
     .pcm    ( pcmdec         )
 );
 

--- a/rtl/jt12/hdl/adpcm/jt10_adpcmb_cnt.v
+++ b/rtl/jt12/hdl/adpcm/jt10_adpcmb_cnt.v
@@ -41,7 +41,7 @@ module jt10_adpcmb_cnt(
     output  reg         chon,
     output  reg         flag,
     input               clr_flag,
-    output  reg         restart,
+    output  reg         clr_dec,
 
     output  reg         adv
 );
@@ -69,6 +69,7 @@ always @(posedge clk or negedge rst_n)
     end
 
 reg set_flag, last_set;
+reg restart;
 
 always @(posedge clk or negedge rst_n)
     if(!rst_n) begin
@@ -88,9 +89,11 @@ always @(posedge clk or negedge rst_n)
         set_flag   <= 'd0;
         chon       <= 'b0;
         restart    <= 'b0;
+		  clr_dec    <= 'b1;
     end else if( !on || clr ) begin
         restart <= 'd0;
         chon <= 'd0;
+		  clr_dec <= 'd1;
     end else if( acmd_up_b && on ) begin
         restart <= 'd1;
     end else if( cen ) begin
@@ -99,15 +102,18 @@ always @(posedge clk or negedge rst_n)
             nibble_sel <= 'b0;
             restart <= 'd0;
             chon <= 'd1;
+            clr_dec <= 'd0;
         end else if( chon && adv ) begin
             if( { addr, nibble_sel } != { aend, 8'hFF, 1'b1 } ) begin
                 { addr, nibble_sel } <= { addr, nibble_sel } + 25'd1;
                 set_flag <= 'd0;
             end else if(arepeat) begin
                 restart <= 'd1;
+                clr_dec <= 'd1;
             end else begin
                 set_flag <= 'd1;
                 chon <= 'd0;
+                clr_dec <= 'd1;
             end
         end
     end // cen

--- a/rtl/jt12/hdl/jt12_mmr.v
+++ b/rtl/jt12/hdl/jt12_mmr.v
@@ -77,6 +77,7 @@ module jt12_mmr(
     output  reg  [15:0] adeltan_b,  // Delta-N
     output  reg  [ 7:0] aeg_b,      // Envelope Generator Control
     output  reg  [ 6:0] flag_ctl,
+    output  reg  [ 6:0] flag_mask,
     // Operator
     output          xuse_prevprev1,
     output          xuse_internal,
@@ -374,7 +375,11 @@ always @(posedge clk) begin : memory_mapped_registers
                             4'h9: adeltan_b[ 7:0] <= din;
                             4'ha: adeltan_b[15:8] <= din;
                             4'hb: aeg_b           <= din;
-                            4'hc: flag_ctl        <= {din[7],din[5:0]}; // this lasts a single clock cycle
+                            4'hc: begin
+									           flag_mask   <= ~{din[7],din[5:0]};
+									           flag_ctl    <= {din[7],din[5:0]}; // this lasts a single clock cycle
+									       end
+                            
                             default:;
                         endcase
                     end

--- a/rtl/jt12/hdl/jt12_top.v
+++ b/rtl/jt12/hdl/jt12_top.v
@@ -159,6 +159,7 @@ wire [ 7:0] aeg_b;         // Envelope Generator Control
 wire [ 5:0] adpcma_flags;  // ADPMC-A read over flags
 wire        adpcmb_flag;
 wire [ 6:0] flag_ctl;
+wire [ 6:0] flag_mask;
 
 
 wire clk_en_2, clk_en_666, clk_en_111, clk_en_55;
@@ -286,8 +287,8 @@ jt12_dout #(.use_ssg(use_ssg),.use_adpcm(use_adpcm)) u_dout(
     .flag_A         ( flag_A        ),
     .flag_B         ( flag_B        ),
     .busy           ( busy          ),
-    .adpcma_flags   ( adpcma_flags  ),
-    .adpcmb_flag    ( adpcmb_flag   ),
+    .adpcma_flags   ( adpcma_flags & flag_mask[5:0] ),
+    .adpcmb_flag    ( adpcmb_flag & flag_mask[6]    ),
     .psg_dout       ( psg_dout      ),
     .addr           ( addr          ),
     .dout           ( dout          )
@@ -353,6 +354,7 @@ jt12_mmr #(.use_ssg(use_ssg),.num_ch(num_ch),.use_pcm(use_pcm), .use_adpcm(use_a
     .adeltan_b  ( adeltan_b     ),  // Delta-N
     .aeg_b      ( aeg_b         ),  // Envelope Generator Control    
     .flag_ctl   ( flag_ctl      ),
+    .flag_mask  ( flag_mask     ),
     // Operator
     .xuse_prevprev1 ( xuse_prevprev1  ),
     .xuse_internal  ( xuse_internal   ),


### PR DESCRIPTION
This change assumes that this line from neogeodev is incorrect:
"Flags must be manually cleared, playing a new sample on the channel won't clear it and the channel will stay silent."
In the third party source ymfm_opn used in MAME, the last phrase ("and the channel will stay silent") is not implemented.  This change attempts to match the behavior of ymfm_opn.

It fixes stereo in Xeno Crisis.