### PR TITLE
Fix rendering the last two sprites to the line buffer

### DIFF
--- a/rtl/video/lspc2_a2.v
+++ b/rtl/video/lspc2_a2.v
@@ -445,7 +445,11 @@ module lspc2_a2(
 	
 	// SS1/2 outputs, periodic
 	wire nFLIP, nCHG_D, R15_QD, S48_nQ;
-	FDPCell O69(CLK_24MB, nFLIP, nRESETP, 1'b1, , FLIP_nQ);
+	
+	// Latch nFLIP at pixel 264 (O62_Q). That will make the line buffers switch at pixel 267.
+	// The first write of the new line to the line buffer happens at pixel 268.
+	//FDPCell O69(CLK_24MB, nFLIP, nRESETP, 1'b1, , FLIP_nQ);
+	FDPCell O69(O62_Q, nFLIP, nRESETP, 1'b1, , FLIP_nQ);
 	FDPCell R63(PIXELC[2], FLIP_nQ, 1'b1, nRESETP, CHG_D, nCHG_D);
 	FDM S48(LSPC_3M, R15_QD, , S48_nQ);
 	// S40A


### PR DESCRIPTION
The line buffers were switched too early (pixel 259) which caused the last two sprites (32 pixels) to be written to the wrong buffer.

Latching the nFLIP signal at pixel 264 will make the line buffers switch at pixel 267. The first write of the new line to the line buffer happens at pixel 268.

@furrtek I don't know if the original hardware does it this way but this does make everything line up perfectly.