### PR TITLE
ADPCM: Fix status flags mask

### DIFF
--- a/rtl/jt12/hdl/adpcm/jt10_adpcmb_cnt.v
+++ b/rtl/jt12/hdl/adpcm/jt10_adpcmb_cnt.v
@@ -77,8 +77,11 @@ always @(posedge clk or negedge rst_n)
         last_set <= 'b0;
     end else begin
         last_set <= set_flag;
-        if( clr_flag ) flag <= 1'b0;
-        if( !last_set && set_flag ) flag <= 1'b1;
+        if( clr_flag ) begin
+            flag <= 1'b0;
+        end else if( !last_set && set_flag ) begin
+            flag <= 1'b1;
+        end
     end
 
 // Address

--- a/rtl/jt12/hdl/jt12_mmr.v
+++ b/rtl/jt12/hdl/jt12_mmr.v
@@ -77,7 +77,6 @@ module jt12_mmr(
     output  reg  [15:0] adeltan_b,  // Delta-N
     output  reg  [ 7:0] aeg_b,      // Envelope Generator Control
     output  reg  [ 6:0] flag_ctl,
-    output  reg  [ 6:0] flag_mask,
     // Operator
     output          xuse_prevprev1,
     output          xuse_internal,
@@ -253,7 +252,6 @@ always @(posedge clk) begin : memory_mapped_registers
         astart_b    <= 0;
         aend_b      <= 0;
         adeltan_b   <= 0;
-        flag_mask   <= 0;
         aeg_b       <= 8'hff;
         // Original test features
         eg_stop     <= 0;
@@ -386,8 +384,7 @@ always @(posedge clk) begin : memory_mapped_registers
                             4'ha: adeltan_b[15:8] <= din;
                             4'hb: aeg_b           <= din;
                             4'hc: begin
-                               flag_mask   <= ~{din[7],din[5:0]};
-                               flag_ctl    <= {din[7],din[5:0]}; // this lasts a single clock cycle
+                               flag_ctl    <= {din[7],din[5:0]};
                            end
                             default:;
                         endcase
@@ -425,7 +422,6 @@ always @(posedge clk) begin : memory_mapped_registers
             { clr_flag_B, clr_flag_A } <= 2'd0;
             psg_wr_n <= 1'b1;
             pcm_wr   <= 1'b0;
-            flag_ctl <= 'd0;
             up_aon   <= 1'b0;
             acmd_up_b <= 1'b0;
         end

--- a/rtl/jt12/hdl/jt12_top.v
+++ b/rtl/jt12/hdl/jt12_top.v
@@ -170,7 +170,6 @@ wire [ 7:0] aeg_b;         // Envelope Generator Control
 wire [ 5:0] adpcma_flags;  // ADPMC-A read over flags
 wire        adpcmb_flag;
 wire [ 6:0] flag_ctl;
-wire [ 6:0] flag_mask;
 wire [ 1:0] div_setting;
 
 wire clk_en_2, clk_en_666, clk_en_111, clk_en_55;
@@ -300,8 +299,8 @@ jt12_dout #(.use_ssg(use_ssg),.use_adpcm(use_adpcm)) u_dout(
     .flag_A         ( flag_A        ),
     .flag_B         ( flag_B        ),
     .busy           ( busy          ),
-    .adpcma_flags   ( adpcma_flags & flag_mask[5:0] ),
-    .adpcmb_flag    ( adpcmb_flag & flag_mask[6]    ),
+    .adpcma_flags   ( adpcma_flags  ),
+    .adpcmb_flag    ( adpcmb_flag   ),
     .psg_dout       ( psg_dout      ),
     .addr           ( addr          ),
     .dout           ( dout          )
@@ -365,7 +364,6 @@ jt12_mmr #(.use_ssg(use_ssg),.num_ch(num_ch),.use_pcm(use_pcm), .use_adpcm(use_a
     .adeltan_b  ( adeltan_b     ),  // Delta-N
     .aeg_b      ( aeg_b         ),  // Envelope Generator Control
     .flag_ctl   ( flag_ctl      ),
-    .flag_mask  ( flag_mask     ),
     // Operator
     .xuse_prevprev1 ( xuse_prevprev1  ),
     .xuse_internal  ( xuse_internal   ),


### PR DESCRIPTION
Remove the one cycle limit for flag_ctl so it is used as mask directly without flag_mask.

flag_mask was incorrectly set to 0 in reset.