### PR TITLE
Add CRT H-Pos and V-Pos adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 # [SNK Neo Geo](https://en.wikipedia.org/wiki/Neo_Geo_(system)) for [MiSTer Platform](https://github.com/MiSTer-devel/Main_MiSTer/wiki) 
 
+> **Note:** This is a fork that supports **CRT offset** — allowing you to adjust the horizontal and vertical position of the image on a CRT TV directly from the OSD.
+
 This is an FPGA implementation of the NEO GEO/MVS system by [Furrtek](https://www.patreon.com/furrtek/posts)
 
 ## Features

--- a/files.qip
+++ b/files.qip
@@ -11,4 +11,5 @@ set_global_assignment -name QIP_FILE rtl/cpu/T80/T80.qip
 set_global_assignment -name VERILOG_FILE rtl/cpu/cpu_z80.v
 set_global_assignment -name VERILOG_FILE rtl/cpu/cpu_68k.v
 set_global_assignment -name SYSTEMVERILOG_FILE neogeo.sv
+set_global_assignment -name VERILOG_FILE rtl/jtframe_resync.v
 set_global_assignment -name SDC_FILE NeoGeo.sdc

--- a/neogeo.sv
+++ b/neogeo.sv
@@ -164,6 +164,9 @@ localparam CONF_STR = {
 	"d5P1o36,Crop Offset,0,2,4,8,10,12,-12,-10,-8,-6,-4,-2;",
 	"P1o78,Scale,Normal,V-Integer,Narrower HV-Integer,Wider HV-Integer;",
 	"P1-;",
+	"P1O[58:54],Analog Video H-Pos,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,-15,-14,-13,-12,-11,-10,-9,-8,-7,-6,-5,-4,-3,-2,-1;",
+	"P1O[63:59],Analog Video V-Pos,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,-15,-14,-13,-12,-11,-10,-9,-8,-7,-6,-5,-4,-3,-2,-1;",
+	"P1-;",
 	"P1O56,Stereo Mix,none,25%,50%,100%;",
 	"P1-;",
 	"-;",
@@ -2098,6 +2101,24 @@ video_cleaner video_cleaner
 	.VBlank_out(vblank)
 );
 
+wire [4:0] crt_hoffset = status[58:54];
+wire [4:0] crt_voffset = status[63:59];
+wire resync_hs, resync_vs;
+
+jtframe_resync #(5) crt_resync
+(
+	.clk(CLK_VIDEO),
+	.pxl_cen(ce_pix),
+	.hs_in(hs),
+	.vs_in(vs),
+	.LVBL(vblank),
+	.LHBL(hblank),
+	.hoffset(-{crt_hoffset[4], crt_hoffset}),
+	.voffset(-{crt_voffset[4], crt_voffset}),
+	.hs_out(resync_hs),
+	.vs_out(resync_vs)
+);
+
 video_mixer #(.LINE_LENGTH(320), .HALF_DEPTH(0), .GAMMA(1)) video_mixer
 (
 	.*,
@@ -2111,8 +2132,8 @@ video_mixer #(.LINE_LENGTH(320), .HALF_DEPTH(0), .GAMMA(1)) video_mixer
 	.B(b),
 
 	// Positive pulses.
-	.HSync(hs),
-	.VSync(vs),
+	.HSync(resync_hs),
+	.VSync(resync_vs),
 	.HBlank(hblank),
 	.VBlank(vblank)
 );

--- a/rtl/jtframe_resync.v
+++ b/rtl/jtframe_resync.v
@@ -1,0 +1,98 @@
+//============================================================================
+//  jtframe_resync - Sync pulse repositioning
+//  Based on JTFRAME (J. Tejada) - ported to MiSTer PSX for CRT H/V offset.
+//
+//  This module re-times the HSYNC and VSYNC pulses by a configurable
+//  offset, allowing the user to recenter the picture on a CRT.
+//
+//  2026 port for PSX_MiSTer
+//============================================================================
+
+module jtframe_resync #(parameter BITS=4)(
+    input         clk,
+    input         pxl_cen,
+    input         hs_in,
+    input         vs_in,
+    input         LVBL,
+    input         LHBL,
+    input  [BITS - 1:0]  hoffset,
+    input  [BITS - 1:0]  voffset,
+    output reg    hs_out,
+    output reg    vs_out
+);
+
+parameter CNTW = 10; // max 1024 pixels/lines
+
+reg [CNTW-1:0]   hs_pos[0:1], vs_hpos[0:1], vs_vpos[0:1],
+                 hs_len[0:1], vs_len[0:1],
+                 hs_cnt,      vs_cnt,
+                 hs_hold,     vs_hold;
+reg              last_LHBL, last_LVBL, last_hsin, last_vsin;
+
+wire             hb_edge, hs_edge, hs_n_edge, vb_edge, vs_edge, vs_n_edge;
+reg              field;
+
+wire [CNTW-1:0]  hpos_off = { {CNTW-BITS{hoffset[BITS - 1]}}, hoffset[(BITS-1):0]  };
+wire [CNTW-1:0]  htrip = hs_pos[field] + hpos_off;
+wire [CNTW-1:0]  vs_htrip = vs_hpos[field] + hpos_off;
+wire [CNTW-1:0]  vs_vtrip = vs_vpos[field] + { {CNTW-BITS{voffset[BITS-1]}}, voffset[(BITS-1):0]  };
+
+assign hb_edge = LHBL && !last_LHBL;
+assign hs_edge = hs_in && !last_hsin;
+assign hs_n_edge = !hs_in && last_hsin;
+assign vb_edge = LVBL && !last_LVBL;
+assign vs_edge = vs_in && !last_vsin;
+assign vs_n_edge = !vs_in && last_vsin;
+
+always @(posedge clk) if(pxl_cen) begin
+    last_LHBL <= LHBL;
+    last_LVBL <= LVBL;
+    last_hsin <= hs_in;
+    last_vsin <= vs_in;
+
+    hs_cnt <= hb_edge ? {CNTW{1'b0}} : hs_cnt+1'b1;
+    if( vb_edge ) begin
+        vs_cnt <= {CNTW{1'b0}};
+        field <= ~field;
+    end else if(hb_edge)
+        vs_cnt <= vs_cnt+1'b1;
+
+    if( hs_edge ) hs_pos[field] <= hs_cnt;
+    if( hs_n_edge ) hs_len[field] <= hs_cnt - hs_pos[field];
+
+    if( hs_cnt == htrip ) begin
+        hs_out <= 1;
+        hs_hold <= hs_len[field] - 1'b1;
+    end else begin
+        if( |hs_hold ) hs_hold <= hs_hold - 1'b1;
+        if( hs_hold == 0 ) hs_out <= 0;
+    end
+
+    if( vs_edge ) begin
+        vs_hpos[field] <= hs_cnt;
+        vs_vpos[field] <= vs_cnt;
+    end
+    if( vs_n_edge ) vs_len[field] <= vs_cnt - vs_vpos[field];
+
+    if( hs_cnt == vs_htrip ) begin
+        if( vs_cnt == vs_vtrip ) begin
+            vs_hold <= vs_len[field] - 1'b1;
+            vs_out <= 1;
+        end else begin
+            if( |vs_hold ) vs_hold <= vs_hold - 1'b1;
+            if( vs_hold == 0 ) vs_out <= 0;
+        end
+    end
+
+end
+
+`ifdef SIMULATION
+initial begin
+    hs_cnt = {CNTW{1'b0}};
+    vs_cnt = {CNTW{1'b0}};
+    hs_out = 0;
+    vs_out = 0;
+end
+`endif
+
+endmodule


### PR DESCRIPTION
Adds CRT horizontal and vertical position adjustment support to the NeoGeo core.

- Adds `jtframe_resync` module to support CRT offset/position adjustment
- Wires up the new module in `files.qip`
- Exposes H-Pos/V-Pos controls in `neogeo.sv` (menu options)
- Updates README with note about CRT offset support

This allows users to fine-tune the image position on CRT displays.